### PR TITLE
Fix for RCE on GetText.php

### DIFF
--- a/var/Typecho/I18n/GetText.php
+++ b/var/Typecho/I18n/GetText.php
@@ -352,7 +352,13 @@ class Typecho_I18n_GetText
             else
                 return $single;
         }
-
+        
+        if(preg_match("/^\d+/", $number, $match)){
+		    $number = $match[0];
+		}else{
+			$number = "";	// You can decide what to do when there is no number at beginning.
+		}
+        
         // find out the appropriate form
         $select = $this->select_string($number);
 


### PR DESCRIPTION
Added regular expression match for number as beginning part of **$number** and rest is ignored. This is helpful is user enter numbers. Such as **123asd**, **456%$#** will be matched and accepted as **123** and **456**. **$number** will be set to blank if not matched. Developer can decide at this point what to do when not matched.